### PR TITLE
Optimized the config to use the aws-ecr orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@1.0.0
   aws-ecr: circleci/aws-ecr@6.8.2
-
 jobs:
   test_app:
     docker:
@@ -25,8 +23,7 @@ jobs:
           root: .
           paths:
             - .
-  
-  build_image:
+  build_and_push_image:
     docker:
       - image: circleci/node:9.11.2
     working_directory: ~/repo
@@ -39,34 +36,17 @@ jobs:
           dockerfile: Dockerfile
           path: ./submodules/goof/
           repo: ${CIRCLE_PROJECT_REPONAME}
-          tag: 'latest,${CIRCLE_BUILD_NUM}'
-
-  push_image:
-    docker:
-      - image: circleci/node:9.11.2
-    working_directory: ~/repo
-    steps:
-      - attach_workspace:
-          at: ~/repo
-      - setup_remote_docker
-      - aws-cli/setup:
-          aws-access-key-id: ACCESS_KEY_ID_ENV_VAR_NAME
-          aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
-          aws-region: AWS_REGION_ENV_VAR_NAME
+          tag: 'latest,<< piepline.number >>'
       - aws-ecr/ecr-login:
           region: AWS_REGION_ENV_VAR_NAME
       - aws-ecr/push-image:
           account-url: AWS_ECR_ACCOUNT_URL_ENV_VAR_NAME
           repo: ${CIRCLE_PROJECT_REPONAME}
-          tag: 'latest,${CIRCLE_BUILD_NUM}'
-
+          tag: 'latest,<< pipeline.number >>'
 workflows:
   build_and_deploy:
     jobs:
       - test_app
-      - build_image:
+      - build_and_push_image:
           requires:
             - test_app
-      - push_image:
-          requires:
-            - build_image


### PR DESCRIPTION
The `<< pipeline.number >>` parameter is the id for the entire build run. The circleci_build_number envar will be different in every and the image tag will not be accurate or what is expected.